### PR TITLE
fix/ECO-2478-snyk-fixes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@contentstack/utils": "^1.1.2",
         "contentstack": "^3.15.3",
         "html-react-parser": "^3.0.4",
-        "moment": "^2.29.3",
+        "moment": "^2.29.4",
         "next": "^13.2.4",
         "next-pwa": "^5.6.0",
         "nprogress": "^0.2.0",
@@ -5086,9 +5086,9 @@
       "dev": true
     },
     "node_modules/moment": {
-      "version": "2.29.3",
-      "resolved": "https://registry.npmjs.org/moment/-/moment-2.29.3.tgz",
-      "integrity": "sha512-c6YRvhEo//6T2Jz/vVtYzqBzwvPT95JBQ+smCytzf7c50oMZRsR/a4w88aD34I+/QVSfnoAnSBFPJHItlOMJVw==",
+      "version": "2.29.4",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.29.4.tgz",
+      "integrity": "sha512-5LC9SOxjSc2HF6vO2CyuTDNivEdoz2IvyJJGj6X8DJ0eFyfszE0QiEd+iXmBvUP3WHxSjFH/vIsA0EN00cgr8w==",
       "engines": {
         "node": "*"
       }
@@ -10630,9 +10630,9 @@
       "dev": true
     },
     "moment": {
-      "version": "2.29.3",
-      "resolved": "https://registry.npmjs.org/moment/-/moment-2.29.3.tgz",
-      "integrity": "sha512-c6YRvhEo//6T2Jz/vVtYzqBzwvPT95JBQ+smCytzf7c50oMZRsR/a4w88aD34I+/QVSfnoAnSBFPJHItlOMJVw=="
+      "version": "2.29.4",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.29.4.tgz",
+      "integrity": "sha512-5LC9SOxjSc2HF6vO2CyuTDNivEdoz2IvyJJGj6X8DJ0eFyfszE0QiEd+iXmBvUP3WHxSjFH/vIsA0EN00cgr8w=="
     },
     "morphdom": {
       "version": "2.6.1",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "@contentstack/utils": "^1.1.2",
     "contentstack": "^3.15.3",
     "html-react-parser": "^3.0.4",
-    "moment": "^2.29.3",
+    "moment": "^2.29.4",
     "next": "^13.2.4",
     "next-pwa": "^5.6.0",
     "nprogress": "^0.2.0",


### PR DESCRIPTION
The Following Snyk Fixes were fixed 
- [[Snyk] Upgrade contentstack from 3.15.2 to 3.15.3](https://github.com/contentstack/contentstack-nextjs-ssg-starter-app/pull/18)
- [[Snyk] Upgrade next-pwa from 5.5.4 to 5.6.0](https://github.com/contentstack/contentstack-nextjs-ssg-starter-app/pull/17)
- [[Snyk] Upgrade html-react-parser from 1.4.14 to 3.0.4](https://github.com/contentstack/contentstack-nextjs-ssg-starter-app/pull/16)
- [[Snyk] Security upgrade moment from 2.29.3 to 2.29.4](https://github.com/contentstack/contentstack-nextjs-ssg-starter-app/pull/12)